### PR TITLE
:string-ci flag controls whether or not the language is case sensitive

### DIFF
--- a/src/wynut/dsl/core.clj
+++ b/src/wynut/dsl/core.clj
@@ -2,14 +2,17 @@
   (:require
    [instaparse.core :as insta]))
 
-(def parse (->> (System/getProperty "user.dir")
-                (format "%s/src/wynut/dsl/grammar.bnf" )
-                slurp
-                insta/parser
-                ))
+(defn get-grammar [] 
+  (->> (System/getProperty "user.dir")
+       (format "%s/src/wynut/dsl/grammar.bnf" )
+       slurp
+       ))
+
+(defn parse [query] 
+ (let [grammar (get-grammar)]
+        ((insta/parser grammar :string-ci true) query)))
 
 (defn evaluate
   "Convert parse tree to abstract syntax tree"
   [parsed]
   (throw (Exception. "Generic evaluation of parse tree is not available. Implementation should be specific to the different storage modules.")))
-


### PR DESCRIPTION
The keywords in the language should be case insensitive so we can use both 'where' and 'WHERE' keywords.